### PR TITLE
Address pedantic lints

### DIFF
--- a/cli/src/bin/subg/param_str/errors.rs
+++ b/cli/src/bin/subg/param_str/errors.rs
@@ -12,7 +12,7 @@ pub(crate) enum ParseError {
 impl Display for ParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ParseError::InvalidValue(message) => write!(f, "InvalidValue: {}", message),
+            ParseError::InvalidValue(message) => write!(f, "InvalidValue: {message}"),
         }
     }
 }
@@ -104,9 +104,9 @@ impl From<FormatError> for FormatStringError {
 impl Display for FormatStringError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            FormatStringError::Parse(error) => write!(f, "{}", error),
-            FormatStringError::Format(error) => write!(f, "{}", error),
-            FormatStringError::ArgumentParse(error) => write!(f, "{}", error),
+            FormatStringError::Parse(error) => write!(f, "{error}"),
+            FormatStringError::Format(error) => write!(f, "{error}"),
+            FormatStringError::ArgumentParse(error) => write!(f, "{error}"),
             FormatStringError::MissingArgument => write!(f, "Missing argument"),
         }
     }

--- a/cli/src/bin/subg/param_str/parsers/format.rs
+++ b/cli/src/bin/subg/param_str/parsers/format.rs
@@ -110,7 +110,7 @@ static PADDING_STATE: FormatState = state(|b, c| -> FormatResult {
         }
         '}' => VARIABLE_STATE.next(b, c),
         _ => Err(ParseError::InvalidValue(
-            format!("Expected 0-9, found {}", c).to_string(),
+            format!("Expected 0-9, found {c}").to_string(),
         )),
     }
 });
@@ -134,7 +134,7 @@ static VARIABLE_STATE: FormatState = state(|b, c| -> FormatResult {
         }
         ':' => Ok(START_PADDING_STATE),
         _ => Err(ParseError::InvalidValue(
-            format!("Expected }}, found {}", c).to_string(),
+            format!("Expected }}, found {c}").to_string(),
         )),
     }
 });

--- a/cli/src/bin/subg/param_str/parsers/range.rs
+++ b/cli/src/bin/subg/param_str/parsers/range.rs
@@ -47,7 +47,7 @@ static INIT_STATE: RangeState = state(|_b, c| -> RangeResult {
     match c {
         '%' => Ok(START_STATE),
         _ => Err(ParseError::InvalidValue(
-            format!("Expected %, found {}", c).to_string(),
+            format!("Expected %, found {c}").to_string(),
         )),
     }
 });
@@ -61,7 +61,7 @@ static START_STATE: RangeState = state(|b, c| -> RangeResult {
         '.' => {
             if b.current_text.is_empty() {
                 return Err(ParseError::InvalidValue(
-                    format!("Expected digit, found {}", c).to_string(),
+                    format!("Expected digit, found {c}").to_string(),
                 ));
             }
             let start = b.current_text.parse::<usize>().unwrap();
@@ -70,7 +70,7 @@ static START_STATE: RangeState = state(|b, c| -> RangeResult {
             Ok(DOT_1_STATE)
         }
         _ => Err(ParseError::InvalidValue(
-            format!("Expected digit or '.', found {}", c).to_string(),
+            format!("Expected digit or '.', found {c}").to_string(),
         )),
     }
 });
@@ -79,7 +79,7 @@ static DOT_1_STATE: RangeState = state(|_b, c| -> RangeResult {
     match c {
         '.' => Ok(END_STATE),
         _ => Err(ParseError::InvalidValue(
-            format!("Expected '.', found {}", c).to_string(),
+            format!("Expected '.', found {c}").to_string(),
         )),
     }
 });
@@ -91,7 +91,7 @@ static END_STATE: RangeState = state(|b, c| -> RangeResult {
             Ok(END_STATE)
         }
         _ => Err(ParseError::InvalidValue(
-            format!("Expected digit, found {}", c).to_string(),
+            format!("Expected digit, found {c}").to_string(),
         )),
     }
 });

--- a/cli/src/bin/subg/subcommands/subnet.rs
+++ b/cli/src/bin/subg/subcommands/subnet.rs
@@ -30,7 +30,7 @@ pub(crate) fn allocate(subg: &SubgArgs, args: &AllocateArgs) {
                 subg::result(
                     pool.allocate(args.bits, Some(name.to_string().as_str())),
                     exitcode::SOFTWARE,
-                    format!("Could not allocate subnet {}", name).as_str(),
+                    format!("Could not allocate subnet {name}").as_str(),
                 );
             }
         }
@@ -63,12 +63,12 @@ pub(crate) fn free(subg: &SubgArgs, args: &FreeArgs) {
                 subg::result(
                     parse_result,
                     exitcode::USAGE,
-                    format!("Could not parse arg IDENTIFIER: {}", identifier).as_str(),
+                    format!("Could not parse arg IDENTIFIER: {identifier}").as_str(),
                 )
             }
         };
         if !pool.free(&cidr) && !args.ignore_missing {
-            eprintln!("Could not free subnet {}", cidr);
+            eprintln!("Could not free subnet {cidr}");
             exit(exitcode::SOFTWARE);
         }
     }
@@ -106,5 +106,5 @@ pub(crate) fn rename(subg: &SubgArgs, args: &RenameArgs) {
 pub(crate) fn max_bits(subg: &SubgArgs) {
     let pool = subg::load_pool(&subg.pool_path);
     let largest = pool.max_available_bits();
-    println!("{}", largest);
+    println!("{largest}");
 }

--- a/cli/src/bin/subg/subcommands/subnet/listing.rs
+++ b/cli/src/bin/subg/subcommands/subnet/listing.rs
@@ -29,9 +29,9 @@ pub(crate) fn cidrs(subg: &SubgArgs, args: &CidrsArgs) {
         if args.long {
             util::right_pad(&mut cidr, max_cidr_width);
             let name = entry.name.clone().unwrap_or("-".to_string());
-            println!("{}  {}", cidr, name);
+            println!("{cidr}  {name}");
         } else {
-            println!("{}", cidr);
+            println!("{cidr}");
         }
     }
 }
@@ -55,9 +55,9 @@ pub(crate) fn names(subg: &SubgArgs, args: &NamesArgs) {
             let cidr = pool.find_by_name(&name).unwrap();
             let cidr_string = cidr.to_string();
             util::right_pad(&mut name, max_name_width);
-            println!("{}  {}", name, cidr_string);
+            println!("{name}  {cidr_string}");
         } else {
-            println!("{}", name);
+            println!("{name}");
         }
     }
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -47,15 +47,16 @@ impl Display for PoolFormat {
 
 fn parse_pool_path(pool_path: &str) -> (&Path, crate::PoolFormat) {
     let path = Path::new(pool_path);
-    let format = match path.extension() {
-        Some(ext) => match ext.to_str().unwrap() {
-            "json" => PoolFormat::Json,
-            "yaml" | "yml" => PoolFormat::Yaml,
-            _ => {
-                eprintln!("Unknown pool file extension: {}", ext.to_str().unwrap());
-                exit(exitcode::USAGE);
-            }
-        },
+    let format = match path
+        .extension()
+        .map(|v| v.to_str().expect("str because path created from str"))
+    {
+        Some("json") => PoolFormat::Json,
+        Some("yaml" | "yml") => PoolFormat::Yaml,
+        Some(ext) => {
+            eprintln!("Unknown pool file extension: {ext}");
+            exit(exitcode::USAGE);
+        }
         None => {
             eprintln!("Pool file has no extension: {}", path.display());
             exit(exitcode::USAGE);

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -15,8 +15,8 @@ pub const DEFAULT_STORAGE_PATH: &str = "subnet-garden-pool.yaml";
 pub const SUBG_COMMAND: &str = "subg";
 
 fn show_error(err: impl Error, message: &str, exit_code: ExitCode) -> ! {
-    eprintln!("{}", message);
-    eprintln!("{}", err);
+    eprintln!("{message}");
+    eprintln!("{err}");
     exit(exit_code);
 }
 
@@ -40,7 +40,7 @@ enum PoolFormat {
 
 impl Display for PoolFormat {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let s = format!("{:?}", self);
+        let s = format!("{self:?}");
         write!(f, "{}", s.to_lowercase())
     }
 }

--- a/cli/tests/fixture/mod.rs
+++ b/cli/tests/fixture/mod.rs
@@ -35,7 +35,7 @@ pub(crate) fn new_test_with_path(path: &str) -> Test {
     Test {
         subg: test,
         _dir: dir,
-        pool_path: pool_path,
+        pool_path,
         pool: pool::SubnetPool::new(TEST_CIDR.parse().unwrap()),
     }
 }


### PR DESCRIPTION
I used `cargo clippy -- -W clippy::pedantic` to guide some cleanup. This only addresses a portion of the warnings, but a lot of the ints seem to have merit. We might want to as some of these lints when we run clippy.